### PR TITLE
Declare matlabr in Imports to fix clean installs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     lubridate,
     lme4,
     lmerTest,
+    matlabr,
     magrittr,
     psych,
     patchwork,

--- a/R/spm_utils.R
+++ b/R/spm_utils.R
@@ -717,7 +717,6 @@ spm_matlab_to_string <- function(x) {
 #' @param spm_path path to spm12 installation; added to MATLAB path at runtime
 #' @param matlab_path location of MATLAB binary; used with matlabr for run_matlab_code()
 #' 
-#' @importFrom matlabr run_matlab_code
 #' @importFrom doParallel registerDoParallel
 #' @importFrom foreach registerDoSEQ foreach %dopar%
 #' @importFrom iterators iter


### PR DESCRIPTION
## This PR fixes a package installation issue in clean environments

### Summary
fmri.pipeline uses matlabr in spm_utils.R via roxygen imports and in foreach(..., .packages = "matlabr"), but matlabr was not declared in DESCRIPTION. As a result, installation from source could fail during lazy loading unless matlabr had already been installed manually.

### Changes
* Added matlabr to Imports in DESCRIPTION
* Cleaned the roxygen import declarations in R/spm_utils.R
* Regenerated NAMESPACE

### Validation
Tested successfully in a clean temporary library within a fresh install context:
* remotes::install_local(..., dependencies = NA) completed successfully
* matlabr was installed automatically into the clean library
* fmri.pipeline installed successfully and loaded correctly afterward